### PR TITLE
Added ContentBlock component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -148,6 +148,14 @@
           },
         ]"
       />
+      <ContentBlock
+        class="row"
+        title="Nempe porem facero eatibusae."
+        intro="Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque et magnis dis parturient montes, nascetur ridiculus mus."
+        :img="require('@/assets/images/Photo_slide.png')"
+        img-alt="cooleimagewoowow"
+        body="Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque et magnis dis parturient montes, nascetur ridiculus mus."
+      />
       <FeaturedDouble
         :items="[
           {
@@ -216,6 +224,7 @@ import StaticCards from '@/components/StaticCards.vue';
 import FeaturedDouble from '@/components/FeaturedDouble.vue';
 import VideoPlayer from '@/components/VideoPlayer.vue';
 import ContactForm from '@/components/ContactForm.vue';
+import ContentBlock from '@/components/ContentBlock.vue';
 
 export default {
   name: 'App',
@@ -224,6 +233,7 @@ export default {
     FeaturedDouble,
     ContactForm,
     VideoPlayer,
+    ContentBlock,
     StaticCards,
     PhotoSlider,
     Button,

--- a/src/components/ContentBlock.vue
+++ b/src/components/ContentBlock.vue
@@ -1,0 +1,62 @@
+<template>
+  <div>
+    <div
+      v-if="title || intro"
+      class="col-md-8 offset-md-2"
+    >
+      <h2 v-if="title">
+        {{ title }}
+      </h2>
+      <p
+        v-if="intro"
+        class="h4"
+      >
+        {{ intro }}
+      </p>
+    </div>
+    <div
+      v-if="img"
+      class="col-md-10 offset-md-1"
+    >
+      <img
+        :src="img"
+        :alt="imgAlt"
+      >
+    </div>
+    <p
+      v-if="body"
+      class="col-md-8  offset-md-2 h5 u-margin-top-lg"
+    >
+      {{ body }}
+    </p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ContentBlock',
+
+  props: {
+    title: {
+      type: String,
+      default: null,
+    },
+    intro: {
+      type: String,
+      default: null,
+    },
+    img: {
+      type: String,
+      default: null,
+    },
+    imgAlt: {
+      type: String,
+      default: null,
+    },
+    body: {
+      type: String,
+      default: null,
+    },
+  },
+};
+</script>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -11,6 +11,7 @@ import StaticCards from './StaticCards.vue';
 import FeaturedDouble from './FeaturedDouble.vue';
 import VideoPlayer from './VideoPlayer.vue';
 import ContactForm from './ContactForm.vue';
+import ContentBlock from './ContentBlock.vue';
 
 export {
   Button,
@@ -22,4 +23,5 @@ export {
   VideoPlayer,
   ContactForm,
   FeaturedDouble,
+  ContentBlock,
 };


### PR DESCRIPTION
# Description
Added a component which can be used for versatile displaying of content.

## Setup
The component is versatile. When you leave out a value, it will not get displayed. This means that you can use this component to just display an image, or a text.

### Missing block
There is a missing block, which is visible in the design but which I did not build. It is this block:
![image](https://user-images.githubusercontent.com/20326539/83956152-2f766500-a85b-11ea-930a-22ffb168d20b.png)
I did not build it, because it is identical to this component:
![image](https://user-images.githubusercontent.com/20326539/83956186-9ac03700-a85b-11ea-9705-fe8278095308.png)
I think that it is better to place the text component under the regular component when you need it. It will keep the complexity of the code lower if we do it in this manner.



## Screenshots
### Desktop
![image](https://user-images.githubusercontent.com/20326539/83956113-d60e3600-a85a-11ea-9155-61cfa40f356d.png)
### Mobile
![image](https://user-images.githubusercontent.com/20326539/83956126-e1616180-a85a-11ea-8a42-ffd6fe0693b5.png)
