### PR TITLE
Fixes the header block image scaling

### DIFF
--- a/src/components/FeaturedHeaderBlock.vue
+++ b/src/components/FeaturedHeaderBlock.vue
@@ -117,7 +117,7 @@ export default {
     text-align: center;
 
     @media (min-width: $breakpoint-xl) {
-      margin-bottom: -12px;
+      margin-bottom: -16px;
     }
   }
 
@@ -131,6 +131,8 @@ export default {
       position: absolute;
       top: 50%;
       left: 50%;
+      width: 100%;
+      height: 100%;
       transform: translate(-50%, -50%);
       object-fit: cover;
     }


### PR DESCRIPTION
# Description
Fixes the scaling of images in the featuredHeader block.

The images scaled based on their aspect ratio which caused the titles to align differently.

## Screenshots
### Desktop
![image](https://user-images.githubusercontent.com/20326539/98959925-15286d80-2504-11eb-9d50-7f9158085c89.png)
### Mobiel
![image](https://user-images.githubusercontent.com/20326539/98959985-22455c80-2504-11eb-8b80-a0999678d8e0.png)
